### PR TITLE
chore: bump version to 5.0.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,13 @@
 tools (5.0.5) unstable; urgency=medium
 
+  * chore: bump version to 5.0.5
+  * adsf
+  * adsf
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Fri, 24 Jan 2025 15:04:37 +0800
+
+tools (5.0.5) unstable; urgency=medium
+
   * adsf
   * adsf
 


### PR DESCRIPTION
update changelog to 5.0.5